### PR TITLE
Add quotes to bosh upload command snippets

### DIFF
--- a/templates/releases/_usage.tmpl
+++ b/templates/releases/_usage.tmpl
@@ -8,4 +8,4 @@
 <p>Or upload it to your director with the <code>upload-release</code> command:</p>
 
 <div class="codehilite"><pre>bosh upload-release --sha1 {{ .TarballSHA1 }} \
-  <a href="{{ .UserVisibleDownloadURL }}" style="color:inherit;">{{ .UserVisibleDownloadURL }}</a></pre></div>
+  "<a href="{{ .UserVisibleDownloadURL }}" style="color:inherit;">{{ .UserVisibleDownloadURL }}</a>"</pre></div>

--- a/templates/stemcells/single.tmpl
+++ b/templates/stemcells/single.tmpl
@@ -25,7 +25,7 @@
         <p>You can upload the latest version to your director with the <code>upload-stemcell</code> command:</p>
 
         <div class="codehilite"><pre>bosh upload-stemcell --sha1 {{ $s.SHA1 }} \
-  <a href="{{ $s.UserVisibleDownloadURL }}" style="color:inherit;">{{ $s.UserVisibleDownloadURL }}</a></pre></div>
+  "<a href="{{ $s.UserVisibleDownloadURL }}" style="color:inherit;">{{ $s.UserVisibleDownloadURL }}</a>"</pre></div>
 
         <p>And reference this stemcell in your deployment manifest from the <code>stemcells</code> section:</p>
 


### PR DESCRIPTION
Commands will fail in some shells if the download URL is not quoted (due to the `?` character).