### PR TITLE
Remove deprecated stemcell lines

### DIFF
--- a/templates/stemcells/_trusty_notice.tmpl
+++ b/templates/stemcells/_trusty_notice.tmpl
@@ -1,4 +1,0 @@
-<div class="admonition warning">
-  <p class="admonition-title">Deprecation Warning</p>
-  <p>Stemcells based on Ubuntu Trusty (14.04) are no longer receiving security updates due to the end of upstream support. We strongly recommend switching to Ubuntu Jammy (22.04) based stemcells.</p>
-</div>

--- a/templates/stemcells/_xenial_notice.tmpl
+++ b/templates/stemcells/_xenial_notice.tmpl
@@ -1,4 +1,0 @@
-<div class="admonition warning">
-  <p class="admonition-title">Deprecation Warning</p>
-  <p>Stemcells based on Ubuntu Xenial (16.04) are no longer receiving security updates from Open Source Cloud Foundry due to the End of Standard Support. We strongly recommend switching to Ubuntu Jammy (22.04) based stemcells.</p>
-</div>

--- a/ui/stemcell/all_distros.go
+++ b/ui/stemcell/all_distros.go
@@ -25,30 +25,6 @@ var (
 
 		Sort: 2,
 	}
-	ubuntuXenialDistro = Distro{
-		NameName: "ubuntu-xenial",
-		Name:     "Ubuntu Xenial",
-
-		OSMatches: []StemcellOSMatch{
-			{OSName: "ubuntu", OSVersion: "xenial"},
-		},
-
-		SupportedInfrastructures: allInfrastructures,
-
-		Sort: 3,
-	}
-	ubuntuTrustyDistro = Distro{
-		NameName: "ubuntu-trusty",
-		Name:     "Ubuntu Trusty",
-
-		OSMatches: []StemcellOSMatch{
-			{OSName: "ubuntu", OSVersion: "trusty"},
-		},
-
-		SupportedInfrastructures: trustyInfrastructures,
-
-		Sort: 4,
-	}
 	windows2019Distro = Distro{
 		NameName: "windows2019",
 		Name:     "Windows 2019",
@@ -63,74 +39,7 @@ var (
 			azureInfrastructure,
 		},
 
-		Sort: 5,
-	}
-	windows1803Distro = Distro{
-		NameName: "windows1803",
-		Name:     "Windows 1803",
-
-		OSMatches: []StemcellOSMatch{
-			{OSName: "windows", OSVersion: "1803"},
-		},
-
-		SupportedInfrastructures: Infrastructures{
-			awsInfrastructure,
-			googleInfrastructure,
-			azureInfrastructure,
-		},
-
-		Sort: 6,
-	}
-	windows2016Distro = Distro{
-		NameName: "windows2016",
-		Name:     "Windows 2016",
-
-		OSMatches: []StemcellOSMatch{
-			{OSName: "windows", OSVersion: "2016"},
-		},
-
-		SupportedInfrastructures: Infrastructures{
-			awsInfrastructure,
-			googleInfrastructure,
-			azureInfrastructure,
-		},
-
-		Sort: 7,
-	}
-	windows2012R2Distro = Distro{
-		NameName: "windows2012R2",
-		Name:     "Windows 2012R2",
-
-		OSMatches: []StemcellOSMatch{
-			{OSName: "windows", OSVersion: "2012R2"},
-		},
-
-		SupportedInfrastructures: Infrastructures{
-			awsInfrastructure,
-			googleInfrastructure,
-			azureInfrastructure,
-		},
-
-		Sort: 8,
-	}
-	centos7Distro = Distro{
-		NameName: "centos-7",
-		Name:     "CentOS 7",
-
-		OSMatches: []StemcellOSMatch{
-			{OSName: "centos", OSVersion: "7"},
-		},
-
-		SupportedInfrastructures: Infrastructures{
-			awsInfrastructure,
-			googleInfrastructure,
-			azureInfrastructure,
-			openstackInfrastructure,
-			vsphereInfrastructure,
-			wardenInfrastructure,
-		},
-
-		Sort: 9,
+		Sort: 3,
 	}
 )
 
@@ -138,12 +47,6 @@ var (
 	allDistros = []Distro{
 		ubuntuJammyDistro,
 		ubuntuBionicDistro,
-		ubuntuXenialDistro,
-		ubuntuTrustyDistro,
 		windows2019Distro,
-		windows1803Distro,
-		windows2016Distro,
-		windows2012R2Distro,
-		centos7Distro,
 	}
 )


### PR DESCRIPTION
The Foundation has adopted a policy of removing support for stemcells older than 3 years:
https://github.com/cloudfoundry/community/blob/1cb77d27fbcdc396d1fa290ceaf5b6aab56fc498/toc/rfc/rfc-0010-stemcell-cleanup.md?plain=1#L26

In order to follow this policy, we need to remove older stemcells from bosh.io in order to prevent broken links.

The last Xenial stemcell was published on April 29th, 2021, and thus passed the 3 year mark earlier this year.