### PR TITLE
Remove non existing stemcells from stemcell overview

### DIFF
--- a/templates/stemcells/all.tmpl
+++ b/templates/stemcells/all.tmpl
@@ -11,13 +11,7 @@
               <li class="md-nav__item">
                 <a href="#ubuntu-jammy" title="Ubuntu Jammy" class="md-nav__link">Ubuntu Jammy</a>
                 <a href="#ubuntu-bionic" title="Ubuntu Bionic" class="md-nav__link">Ubuntu Bionic</a>
-                <a href="#ubuntu-xenial" title="Ubuntu Xenial" class="md-nav__link">Ubuntu Xenial</a>
-                <a href="#ubuntu-trusty" title="Ubuntu Trusty" class="md-nav__link">Ubuntu Trusty</a>
                 <a href="#windows2019" title="Windows 2019" class="md-nav__link">Windows 2019</a>
-                <a href="#windows1803" title="Windows 1803" class="md-nav__link">Windows 1803</a>
-                <a href="#windows2016" title="Windows 2016" class="md-nav__link">Windows 2016</a>
-                <a href="#windows2012R2" title="Windows 2012R2" class="md-nav__link">Windows 2012R2</a>
-                <a href="#centos-7" title="CentOS 7" class="md-nav__link">CentOS 7</a>
               </li>
             </ul>
           </nav>


### PR DESCRIPTION
Currently the page https://bosh.cloudfoundry.org/stemcells does still show Xenial/ Trusty/ various Windows and CentOS stemcell which do not have any content anymore 