### PR TITLE
set agentType default blank

### DIFF
--- a/stemcell/stemsrepo/s3_stemcell.go
+++ b/stemcell/stemsrepo/s3_stemcell.go
@@ -19,7 +19,7 @@ var (
 			`(?P<name>(?P<inf_name>\w+)-` +
 			`(?P<hv_name>\w+(-\w+)?)-` +
 			`(?P<os_name>centos|ubuntu|windows)` +
-			`(?P<os_version>-trusty|-xenial|-bionic|-jammy|-jammy-fips|-lucid|2019|1803|2016|2012R2|-\d+)?` +
+			`(?P<os_version>-trusty|-xenial|-bionic|-jammy|-jammy-fips|-noble|-lucid|2019|1803|2016|2012R2|-\d+)?` +
 			`(?P<agent_type>-go_agent)?` +
 			`(?P<disk_fmt>-raw)?)` +
 			`\.tgz\z`,
@@ -50,7 +50,7 @@ type S3Stemcell struct {
 	osName    string // e.g. Ubuntu
 	osVersion string // e.g. Trusty
 
-	agentType string // e.g. Ruby
+	agentType string // e.g. Go
 
 	url string
 }
@@ -78,7 +78,7 @@ func NewS3Stemcell(key, etag, sha1 string, sha256 string, size uint64, lastModif
 	if len(m["agent_type"]) > 0 {
 		agentType = strings.Trim(m["agent_type"], "-")
 	} else {
-		agentType = "ruby_agent"
+		agentType = ""
 	}
 
 	if s3StemcellAgentRegexp.MatchString(osVersion) {

--- a/stemcell/stemsrepo/s3_stemcell_test.go
+++ b/stemcell/stemsrepo/s3_stemcell_test.go
@@ -25,58 +25,6 @@ var _ = Describe("NewS3Stemcell", func() {
 	}
 
 	var examples = map[string]ExtractedPieces{
-		"bosh-stemcell/aws/bosh-stemcell-891-aws-xen-ubuntu.tgz": ExtractedPieces{
-			Name:    "bosh-aws-xen-ubuntu",
-			Version: "891",
-
-			InfName: "aws",
-			HvName:  "xen",
-
-			OSName:    "ubuntu",
-			OSVersion: "lucid",
-
-			AgentType: "ruby",
-		},
-
-		"bosh-stemcell/aws/bosh-stemcell-2311-aws-xen-centos-go_agent.tgz": ExtractedPieces{
-			Name:    "bosh-aws-xen-centos-go_agent",
-			Version: "2311",
-
-			InfName: "aws",
-			HvName:  "xen",
-
-			OSName:    "centos",
-			OSVersion: "",
-
-			AgentType: "go",
-		},
-
-		"bosh-stemcell/aws/bosh-stemcell-2446-aws-xen-ubuntu-lucid-go_agent.tgz": ExtractedPieces{
-			Name:    "bosh-aws-xen-ubuntu-lucid-go_agent",
-			Version: "2446",
-
-			InfName: "aws",
-			HvName:  "xen",
-
-			OSName:    "ubuntu",
-			OSVersion: "lucid",
-
-			AgentType: "go",
-		},
-
-		"micro-bosh-stemcell/aws/light-micro-bosh-stemcell-891-aws-xen-ubuntu.tgz": ExtractedPieces{
-			Name:    "bosh-aws-xen-ubuntu",
-			Version: "891",
-
-			InfName: "aws",
-			HvName:  "xen",
-
-			OSName:    "ubuntu",
-			OSVersion: "lucid",
-
-			AgentType: "ruby",
-		},
-
 		"micro-bosh-stemcell/warden/bosh-stemcell-56-warden-boshlite-ubuntu-lucid-go_agent.tgz": ExtractedPieces{
 			Name:    "bosh-warden-boshlite-ubuntu-lucid-go_agent",
 			Version: "56",
@@ -88,19 +36,6 @@ var _ = Describe("NewS3Stemcell", func() {
 			OSVersion: "lucid",
 
 			AgentType: "go",
-		},
-
-		"bosh-stemcell/aws/light-bosh-stemcell-2579-aws-xen-centos.tgz": ExtractedPieces{
-			Name:    "bosh-aws-xen-centos",
-			Version: "2579",
-
-			InfName: "aws",
-			HvName:  "xen",
-
-			OSName:    "centos",
-			OSVersion: "",
-
-			AgentType: "ruby",
 		},
 
 		"bosh-stemcell/aws/light-bosh-stemcell-2579-aws-xen-centos-go_agent.tgz": ExtractedPieces{
@@ -333,6 +268,20 @@ var _ = Describe("NewS3Stemcell", func() {
 			OSVersion: "jammy",
 
 			AgentType: "go",
+		},
+
+		// Ubuntu noble
+		"aws/bosh-stemcell-40-aws-xen-hvm-ubuntu-noble.tgz": ExtractedPieces{
+			Name:    "bosh-aws-xen-hvm-ubuntu-noble",
+			Version: "40",
+
+			InfName: "aws",
+			HvName:  "xen-hvm",
+
+			OSName:    "ubuntu",
+			OSVersion: "noble",
+
+			AgentType: "",
 		},
 	}
 


### PR DESCRIPTION
as we do not use the ruby agent anymore in any stemcell we provide we can reuse it now for noble. as from noble forward we will not provide the agent type anymore in the stemcell filename