### PR TITLE
Provide SHA256 for bosh releases

### DIFF
--- a/templates/releases/_usage.tmpl
+++ b/templates/releases/_usage.tmpl
@@ -3,9 +3,9 @@
 <div class="codehilite"><pre>- name: "{{ .Name }}"
   version: "{{ .Version }}"
   url: "<a href="{{ .UserVisibleDownloadURL }}" style="color:inherit;">{{ .UserVisibleDownloadURL }}</a>"
-  sha1: "{{ .TarballSHA1 }}"</pre></div>
+  sha1: sha256:{{ .TarballSHA256 }}</pre></div>
 
 <p>Or upload it to your director with the <code>upload-release</code> command:</p>
 
-<div class="codehilite"><pre>bosh upload-release --sha1 {{ .TarballSHA1 }} \
+<div class="codehilite"><pre>bosh upload-release --sha2 {{ .TarballSHA256 }} \
   "<a href="{{ .UserVisibleDownloadURL }}" style="color:inherit;">{{ .UserVisibleDownloadURL }}</a>"</pre></div>

--- a/templates/releases/show_versions.tmpl
+++ b/templates/releases/show_versions.tmpl
@@ -93,9 +93,16 @@
               <li>
                 <a href="{{ .DownloadURL }}">Release Tarball</a>
                 &ndash;
-                {{ if .TarballSHA1 }}
-                  <code class="codehilite">sha1:{{ .TarballSHA1 }}</code>
-                {{ end }}
+                  {{ if and .TarballSHA1 .TarballSHA256 }}
+                    <button onclick="toggleHash(this)">SHA256 ⇋</button>
+                  {{ end }}
+                  <br>
+                  {{ with .TarballSHA1 }}
+                    <code class="codehilite hash sha1">sha1:{{ . }}</code>
+                  {{ end }}
+                  {{ with .TarballSHA256 }}
+                    <code class="codehilite hash sha256" style="display: none">sha1: sha256:{{ . }}</code>
+                  {{ end }}
               </li>
             </ul>
           {{ end }}
@@ -103,6 +110,20 @@
           <p class="empty">No release versions</p>
         {{ end }}
       </article>
+      <script>
+          function toggleHash(button) {
+            const li = button.closest('li');
+            const sha1 = li.querySelector('.sha1');
+            const sha256 = li.querySelector('.sha256');
+
+            if (sha1 && sha256) {
+              const showingSHA1 = sha1.style.display !== 'none';
+              sha1.style.display = showingSHA1 ? 'none' : 'inline';
+              sha256.style.display = showingSHA1 ? 'inline' : 'none';
+              button.textContent = `${showingSHA1 ? 'SHA1 ⇋' : 'SHA256 ⇋'}`;
+            }
+          }
+      </script>
     </div>
   </div>
 </main>


### PR DESCRIPTION
As SHA-2 is regarded as a more recommended approach, may be it makes sense that we include it in our documentation as well.

With this PR I make SHA256 as the default code example to upload a release:
<img width="834" height="285" alt="image" src="https://github.com/user-attachments/assets/269a77e9-289f-4cc7-8d04-4e6ebdf3f903" />

Both SHA1 and SHA256 values are provided, switchable with a button (may be it could made to look nicer)
SHA1 is shown as default

<img width="521" height="263" alt="image" src="https://github.com/user-attachments/assets/30b1f6ad-b29e-4d77-9402-a67d845a366a" />

Once you click on SHA256, the SHA256 value is then shown:

<img width="845" height="180" alt="image" src="https://github.com/user-attachments/assets/7f27e9b3-8e22-428b-ae94-a813511879e2" />