### PR TITLE
Use sha1 command option even for sha256 checksums

### DIFF
--- a/templates/releases/_usage.tmpl
+++ b/templates/releases/_usage.tmpl
@@ -7,5 +7,5 @@
 
 <p>Or upload it to your director with the <code>upload-release</code> command:</p>
 
-<div class="codehilite"><pre>bosh upload-release --sha2 {{ .TarballSHA256 }} \
+<div class="codehilite"><pre>bosh upload-release --sha1=sha256:{{ .TarballSHA256 }} \
   "<a href="{{ .UserVisibleDownloadURL }}" style="color:inherit;">{{ .UserVisibleDownloadURL }}</a>"</pre></div>


### PR DESCRIPTION
`--sha2` parameter does not exist for `upload-release` instead `--sha1` must be used with `sha256:` prefix

cf. https://github.com/cloudfoundry/bosh-cli/blob/main/cmd/upload_release.go