### PR TITLE
Update all_infrastructures.go

### DIFF
--- a/ui/stemcell/all_infrastructures.go
+++ b/ui/stemcell/all_infrastructures.go
@@ -123,7 +123,7 @@ var (
 		awsInfrastructure,
 		googleInfrastructure,
 		azureInfrastructure,
-    	alicloudInfrastructure,
+		alicloudInfrastructure,
 		openstackInfrastructure,
 		vsphereInfrastructure,
 		wardenInfrastructure,

--- a/ui/stemcell/all_infrastructures.go
+++ b/ui/stemcell/all_infrastructures.go
@@ -123,6 +123,7 @@ var (
 		awsInfrastructure,
 		googleInfrastructure,
 		azureInfrastructure,
+    	alicloudInfrastructure,
 		openstackInfrastructure,
 		vsphereInfrastructure,
 		wardenInfrastructure,


### PR DESCRIPTION
Alicloud was missing in the list of the supported infrastructures for noble